### PR TITLE
BugFixed:字幕合并处理执行失败

### DIFF
--- a/src/core/srt/srt_segmentor.py
+++ b/src/core/srt/srt_segmentor.py
@@ -191,8 +191,8 @@ class SrtSegmentor(BaseObject):
         split_index = n // 2 if all_equal else self._find_split_index(segs_to_merge, n)
 
         # 递归拆分
-        first_segs = segs_to_merge[:split_index + 1]
-        second_segs = segs_to_merge[split_index + 1:]
+        first_segs = segs_to_merge[:split_index]
+        second_segs = segs_to_merge[split_index:]
         return self._split_long_segment(first_segs) + self._split_long_segment(second_segs)
 
     @staticmethod


### PR DESCRIPTION
StepProcessor - ERROR - 步骤 '字幕合并处理...' 执行失败: maximum recursion depth exceeded while calling a Python object